### PR TITLE
fix: use newer call signature of aur module

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,4 +35,4 @@
   aur:
     name: yay
     use: makepkg
-    skip_installed: true
+    state: present


### PR DESCRIPTION
When trying to run the role, I got this error: `Unsupported parameters for (aur) module: skip_installed`

It looks like the `skip_installed` flag has been removed, and replaced with setting `state` to `present`.

This commit uses this new signature to install the `yay` package.